### PR TITLE
Add error feedback on jenkins job updates

### DIFF
--- a/app/jobs.js
+++ b/app/jobs.js
@@ -102,20 +102,20 @@ const jobs = (jenkins, db) => {
 const dumpRequesError = (r) => {
   console.error(`There was an error contacting your Jenkins instance:`);
   if (r == null) {
-    console.error(`No request data: Network error. Check your JENKINS_URL setting.`)
-    return
+    console.error(`No request data: Network error. Check your JENKINS_URL setting.`);
+    return;
   }
-  uri = r.request.uri
-  url = `${uri.protocol}//${filterAuth(uri.auth)}${uri.hostname}${uri.path}`
-  console.error(`${url} => ${r.statusCode} ${r.statusMessage}`)
+  uri = r.request.uri;
+  url = `${uri.protocol}//${filterAuth(uri.auth)}${uri.hostname}${uri.path}`;
+  console.error(`${url} => ${r.statusCode} ${r.statusMessage}`);
 }
 
 const filterAuth = (auth) => {
   if (auth == '') {
-    return ''
+    return '';
   }
-  parts = auth.split(":", 1)
-  return `${parts[0]}:**hidden*secret**@`
+  parts = auth.split(":", 1);
+  return `${parts[0]}:**hidden*secret**@`;
 }
 
 module.exports = jobs;

--- a/app/jobs.js
+++ b/app/jobs.js
@@ -35,7 +35,7 @@ const setup = (jenkins, db) => {
 
       jenkins.all_jobs((err, data) => {
         if (err) {
-          console.error(`There was an error contacting your Jenkins instance`);
+          dumpRequesError(data)
           return;
         }
 
@@ -61,7 +61,7 @@ const update = (jenkins, db) => {
   console.log('Updating jobs...');
   jenkins.all_jobs((err, data) => {
     if (err) {
-      console.error(`There was an error contacting your Jenkins instance`);
+      dumpRequesError(data)
       return;
     }
 
@@ -98,5 +98,24 @@ const jobs = (jenkins, db) => {
     update: () => update(jenkins, db),
   };
 };
+
+function dumpRequesError(r) {
+  console.error(`There was an error contacting your Jenkins instance:`);
+  if (r == null) {
+    console.error(`No request data: Network error. Check your JENKINS_URL setting.`)
+    return
+  }
+  uri = r.request.uri
+  url = `${uri.protocol}//${filterAuth(uri.auth)}${uri.hostname}${uri.path}`
+  console.error(`${url} => ${r.statusCode} ${r.statusMessage}`)
+}
+
+function filterAuth(auth) {
+  if (auth == '') {
+    return ''
+  }
+  parts = auth.split(":", 1)
+  return `${parts[0]}:**hidden*secret**@`
+}
 
 module.exports = jobs;

--- a/app/jobs.js
+++ b/app/jobs.js
@@ -99,7 +99,7 @@ const jobs = (jenkins, db) => {
   };
 };
 
-function dumpRequesError(r) {
+const dumpRequesError = (r) => {
   console.error(`There was an error contacting your Jenkins instance:`);
   if (r == null) {
     console.error(`No request data: Network error. Check your JENKINS_URL setting.`)
@@ -110,7 +110,7 @@ function dumpRequesError(r) {
   console.error(`${url} => ${r.statusCode} ${r.statusMessage}`)
 }
 
-function filterAuth(auth) {
+const filterAuth = (auth) => {
   if (auth == '') {
     return ''
   }


### PR DESCRIPTION
For HTTP errors you get output like:

```
backend_1  | Updating jobs...
backend_1  | There was an error contacting your Jenkins instance:
backend_1  | http://josvaz:**hidden*secret**@jenkins-webdev.nami/jenkins/api/json => 401 Unauthorized
```
```
backend_1  | Updating jobs...
backend_1  | There was an error contacting your Jenkins instance:
backend_1  | http://josvaz:**hidden*secret**@jenkins-webdev.nami/jenkin/api/json => 404 Not Found
```

For network errors that don't return a request object at all you get:
```
backend_1  | Updating jobs...
backend_1  | There was an error contacting your Jenkins instance:
backend_1  | No request data: Network error. Check your JENKINS_URL setting.
```